### PR TITLE
api ssl setup

### DIFF
--- a/zoo_api/CHANGELOG.MD
+++ b/zoo_api/CHANGELOG.MD
@@ -10,9 +10,16 @@ Format:
 ...
 ```
 
+## 0.1.1 - 2019-02-04
+### Added
+* ssh for loopback based off their template repo: [link](https://github.com/strongloop/loopback-example-ssl)
+* update documentation on some of the ssh setup
+
+### Breaking
+* add new `.env` variable `HTTP` which needs set to true if not utilizing https and don't want to get annoying popups about invalid certs
+
 ## 0.1.0 - 2019-02-04
 ### Added
 * `changelog.md`
 * `.env` file to secure our MySQL connection information
 * documentation around `.env` and `README.MD` file
-* 

--- a/zoo_api/README.md
+++ b/zoo_api/README.md
@@ -25,6 +25,7 @@ DB_HOST=ip/url
 DB_USER=coolUser
 DB_PASS=coolPass
 DB=dbName
+HTTP=true ### set to false if https is desired. can only do one or the other
 ```
 
 dotenv allows us to keep our connections secure and they won't get overritten during a deploy since they are not tracked by git. 
@@ -37,6 +38,10 @@ dotenv allows us to keep our connections secure and they won't get overritten du
     b. use the `automigrate.js` script under `/server` to create tables for all the user tables needed by Loopback
 3. Working with an existing MySQL database? (zoo schema already applied)
     a. Run script on `2b` if haven't already
+4. generate some SSL certs via your favorite SSL cert generator and store them in `./zoo_api/server/private/`
+    a. private key filename needs to be: `privatekey.pem`
+    b. certifacte filename needs to be: `certificate.pem`
+    c. `.env` file needs an HTTP attribute set to false in order to run on https
 
 ### DEPLOYMENT
 Using [PM2](https://www.npmjs.com/package/pm2) - go up to the root directory of the mono-repo and run `pm2 start` this will run 2 instances of the API and 2 instances of the frontend.

--- a/zoo_api/server/config.json
+++ b/zoo_api/server/config.json
@@ -1,6 +1,6 @@
 {
   "restApiRoot": "/api",
-  "host": "0.0.0.0",
+  "host": "localhost",
   "port": 3333,
   "remoting": {
     "context": false,

--- a/zoo_api/server/server.js
+++ b/zoo_api/server/server.js
@@ -1,6 +1,9 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: loopback-example-ssl
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 'use strict';
 var path = require('path');
-
 require('dotenv').config({
   path: path.join(__dirname, '../.env'),
 });
@@ -8,27 +11,43 @@ require('dotenv').config({
 var loopback = require('loopback');
 var boot = require('loopback-boot');
 
+var http = require('http');
+var https = require('https');
+var sslConfig = require('./ssl-config');
+
 var app = module.exports = loopback();
 
-app.start = function() {
-  // start the web server
-  return app.listen(function() {
-    app.emit('started');
-    var baseUrl = app.get('url').replace(/\/$/, '');
-    console.log('Web server listening at: %s', baseUrl);
+// boot scripts mount components like REST API
+boot(app, __dirname);
+
+app.start = function(httpOnly) {
+  if (httpOnly === undefined) {
+    httpOnly = process.env.HTTP;
+  }
+  var server = null;
+  if (!httpOnly) {
+    var options = {
+      key: sslConfig.privateKey,
+      cert: sslConfig.certificate,
+    };
+    server = https.createServer(options, app);
+  } else {
+    console.log('http only');
+    server = http.createServer(app);
+  }
+  server.listen(app.get('port'), function() {
+    var baseUrl = (httpOnly ? 'http://' : 'https://') + app.get('host') + ':' + app.get('port');
+    app.emit('started', baseUrl);
+    console.log('LoopBack server listening @ %s%s', baseUrl, '/');
     if (app.get('loopback-component-explorer')) {
       var explorerPath = app.get('loopback-component-explorer').mountPath;
       console.log('Browse your REST API at %s%s', baseUrl, explorerPath);
     }
   });
+  return server;
 };
 
-// Bootstrap the application, configure models, datasources and middleware.
-// Sub-apps like REST API are mounted via boot scripts.
-boot(app, __dirname, function(err) {
-  if (err) throw err;
-
-  // start the server if `$ node server.js`
-  if (require.main === module)
-    app.start();
-});
+// start the server if `$ node server.js`
+if (require.main === module) {
+  app.start();
+}

--- a/zoo_api/server/ssl-config.js
+++ b/zoo_api/server/ssl-config.js
@@ -1,0 +1,7 @@
+'use strict';
+var path = require('path');
+var fs = require('fs');
+exports.privateKey = fs.readFileSync(path.join(__dirname,
+    './private/privatekey.pem')).toString();
+exports.certificate = fs.readFileSync(path.join(__dirname,
+    './private/certificate.pem')).toString();


### PR DESCRIPTION
## Motivation / Context
* when the project is deployed it's optimal to have the api served through https to prevent strange chrome related issues I've seen in other projects. 
* server.js has been modified according to [example](https://github.com/strongloop/loopback-example-ssl) with our .env path fixes

### Added
* some docs
* ssh functionality

### Breaking
* HTTP var added to `.env` file that will need to be present and set to true if you don't want annoying invalid https popups for the api if you don't have valid certs on your dev machine.
