### PR TITLE
Bugfix/next css redirect issue

### DIFF
--- a/zoo_frontend/pages/_app.jsx
+++ b/zoo_frontend/pages/_app.jsx
@@ -9,6 +9,8 @@ import getPageContext from '../src/getPageContext';
 import AuthProvider, { AuthContext } from '../src/util/AuthProvider';
 import PageLayout from '../src/util/PageLayout';
 
+import './blank.css';
+
 class MyApp extends App {
   static async getInitialProps({ ctx, Component }) {
     let pageProps = {};

--- a/zoo_frontend/src/api/Api.js
+++ b/zoo_frontend/src/api/Api.js
@@ -39,7 +39,7 @@ class Api {
         LocalStorage.setLastName(data.lastName);
         LocalStorage.setRole(data.role);
         LocalStorage.setId(data.id);
-        document.cookie = `authToken=${res.data.token};`;
+        document.cookie = `authToken=${res.data.token}; path=/`;
         this.setToken(res.data.token);
       } else {
         throw new Error('Invalid login return');
@@ -68,7 +68,7 @@ class Api {
       }
     }
     this.token = '';
-    document.cookie = 'authToken=;';
+    document.cookie = 'authToken=; path=/';
   }
 }
 

--- a/zoo_frontend/src/api/Api.js
+++ b/zoo_frontend/src/api/Api.js
@@ -17,18 +17,13 @@ class Api {
   }
 
   validateToken = async () => {
-    try {
-      if (this.token === '' || this.token === 'undefined') {
-        throw new Error('Session Token Blank');
-      }
-      return await axios.post(`${API_BASE_URL}/api/AccessTokens/validate`, {
-        token: this.token,
-      });
-    } catch (err) {
-      document.cookie = 'authToken=; path=/';
-      this.token = '';
-      throw err;
+    if (this.token === '' || this.token === 'undefined') {
+      console.log('tried validating blank token in validateToken(), please verify this was intentional');
+      throw new Error('Session Token Blank');
     }
+    await axios.post(`${API_BASE_URL}/api/AccessTokens/validate`, {
+      token: this.token,
+    });
   }
 
   login = async (email, password) => {
@@ -44,7 +39,7 @@ class Api {
         LocalStorage.setLastName(data.lastName);
         LocalStorage.setRole(data.role);
         LocalStorage.setId(data.id);
-        document.cookie = `authToken=${res.data.token}; path=/`;
+        document.cookie = `authToken=${res.data.token};`;
         this.setToken(res.data.token);
       } else {
         throw new Error('Invalid login return');
@@ -73,7 +68,7 @@ class Api {
       }
     }
     this.token = '';
-    document.cookie = 'authToken=; path=/';
+    document.cookie = 'authToken=;';
   }
 }
 

--- a/zoo_frontend/src/api/Api.js
+++ b/zoo_frontend/src/api/Api.js
@@ -27,11 +27,10 @@ class Api {
   }
 
   login = async (email, password) => {
-    try {
-      const res = await axios.post(`${API_BASE_URL}/api/accounts/login`, {
-        email,
-        password,
-      });
+    await axios.post(`${API_BASE_URL}/api/accounts/login`, {
+      email,
+      password,
+    }).then((res) => {
       const { data } = res;
       if (data) {
         LocalStorage.setEmail(data.email);
@@ -44,10 +43,13 @@ class Api {
       } else {
         throw new Error('Invalid login return');
       }
-    } catch (err) {
-      console.error(err);
-      throw err;
-    }
+    }, (err) => {
+      if (err.response && err.response.data && err.response.data.error) {
+        throw err.response.data.error;
+      } else {
+        throw err;
+      }
+    });
   }
 
   logout = async () => {

--- a/zoo_frontend/src/pages/admin/user/user.jsx
+++ b/zoo_frontend/src/pages/admin/user/user.jsx
@@ -351,7 +351,7 @@ class User extends Component {
     resolve();
   })
 
-  handlePasswordTextChange = (passwordText) => this.setState({ passwordText })
+  handlePasswordTextChange = (evt) => this.setState({ passwordText: evt.target.value })
 
   handlePasswordSubmit = (event) => {
     event.preventDefault();

--- a/zoo_frontend/src/pages/login/login.jsx
+++ b/zoo_frontend/src/pages/login/login.jsx
@@ -14,6 +14,8 @@ import Typography from '@material-ui/core/Typography';
 
 import LocalStorage from '../../static/LocalStorage';
 
+import Notifications from '../../components/Notifications';
+
 class Login extends Component {
   static propTypes = {
     api: PropTypes.object.isRequired,
@@ -39,6 +41,8 @@ class Login extends Component {
       error: false,
       errorMessage: '',
     };
+
+    this.notificationsRef = React.createRef();
   }
 
   componentDidMount() {
@@ -60,8 +64,17 @@ class Login extends Component {
 
     try {
       await this.props.api.login(email, password);
-      Router.push('/');
+      if (process.browser) {
+        Router.events.on('routeChangeError', (err) => {
+          console.error(err);
+          this.notificationsRef.current.showNotification('error', 'Application redirection error, please close browser and re-open');
+        }); // leaving this in, let's us see if there are weird /login redirect issues
+
+        Router.push('/'); // previous block checks if this was successfull or not
+      }
+      return;
     } catch (err) {
+      console.error(err);
       this.setState({ error: true, errorMessage: 'Invalid username/password!' });
     }
   }
@@ -140,6 +153,7 @@ class Login extends Component {
             </Button>
           </form>
         </Paper>
+        <Notifications ref={this.notificationsRef} />
       </div>
     );
   }

--- a/zoo_frontend/src/pages/login/login.jsx
+++ b/zoo_frontend/src/pages/login/login.jsx
@@ -76,7 +76,6 @@ class Login extends Component {
       }
       return;
     } catch (err) {
-      console.log(err.message);
       if (err.message === 'Role not found') {
         setTimeout(() => {
           this.notificationsRef.current.showNotification('error', 'This user has no role, please contact the system admin to add a user type to your account');

--- a/zoo_frontend/src/pages/login/login.jsx
+++ b/zoo_frontend/src/pages/login/login.jsx
@@ -67,13 +67,21 @@ class Login extends Component {
       if (process.browser) {
         Router.events.on('routeChangeError', (err) => {
           console.error(err);
-          this.notificationsRef.current.showNotification('error', 'Application redirection error, please close browser and re-open');
+          if (this.notificationsRef && this.notificationsRef.current) {
+            this.notificationsRef.showNotification('error', 'Application redirection error, please close browser and re-open');
+          }
         }); // leaving this in, let's us see if there are weird /login redirect issues
 
         Router.push('/'); // previous block checks if this was successfull or not
       }
       return;
     } catch (err) {
+      console.log(err.message);
+      if (err.message === 'Role not found') {
+        setTimeout(() => {
+          this.notificationsRef.current.showNotification('error', 'This user has no role, please contact the system admin to add a user type to your account');
+        }, 500);
+      }
       console.error(err);
       this.setState({ error: true, errorMessage: 'Invalid username/password!' });
     }

--- a/zoo_frontend/src/util/withAuth.jsx
+++ b/zoo_frontend/src/util/withAuth.jsx
@@ -51,9 +51,7 @@ export default (allowedRoles = ['authenticated']) => (WrappedComponent) => {
 
       const api = new Api(c.authToken);
       try {
-        await api.validateToken().then(async () => {
-          // console.log('pass validation');
-        });
+        await api.validateToken();
 
         if (WrappedComponent.getInitialProps) {
           ctx.authToken = c.authToken;

--- a/zoo_frontend/src/util/withAuth.jsx
+++ b/zoo_frontend/src/util/withAuth.jsx
@@ -19,6 +19,14 @@ const redirectTo = (destination, { res, status } = {}) => {
   }
 };
 
+Router.events.on('routeChangeError', (error) => {
+  console.error('route change status[❌]', error.message);
+});
+
+Router.events.on('routeChangeComplete', (evt) => {
+  console.log('route change status[✔] path:', evt);
+});
+
 export default (allowedRoles = ['authenticated']) => (WrappedComponent) => {
   class withAuth extends Component {
     static async getInitialProps(ctx) {
@@ -34,8 +42,10 @@ export default (allowedRoles = ['authenticated']) => (WrappedComponent) => {
           return { ...pageProps };
         }
 
+        console.log('redirect to login because user has no session token');
         // redirecting to login because current page does not support unauth users
         redirectTo('/login', { res: ctx.res, status: 301 });
+        console.log('success');
         return { ...pageProps };
       }
 
@@ -43,14 +53,8 @@ export default (allowedRoles = ['authenticated']) => (WrappedComponent) => {
       try {
         await api.validateToken().then(async () => {
           // console.log('pass validation');
-        }, () => {
-          if (process.browser) {
-            document.cookie = 'authToken=; path=/';
-          }
-          api.setToken('');
-          redirectTo('/login', { res: ctx.res, status: 301 });
-          return { ...pageProps };
         });
+
         if (WrappedComponent.getInitialProps) {
           ctx.authToken = c.authToken;
           pageProps = await WrappedComponent.getInitialProps(ctx);
@@ -65,6 +69,8 @@ export default (allowedRoles = ['authenticated']) => (WrappedComponent) => {
         if (process.browser) {
           document.cookie = 'authToken=; path=/';
         }
+        api.setToken('');
+        console.log('redirect to login because users key did not validate properly on server end');
         redirectTo('/login', { res: ctx.res, status: 301 });
         return { ...pageProps };
       }
@@ -102,6 +108,7 @@ export default (allowedRoles = ['authenticated']) => (WrappedComponent) => {
       };
 
       if (!allowedRoles.includes(account.role)) {
+        console.log('redirect user to login if not authenticated, or redirect to home page because no access');
         Router.push(account.role === 'unauthenticated' ? '/login' : '/');
         return;
       }

--- a/zoo_frontend/src/util/withAuth.jsx
+++ b/zoo_frontend/src/util/withAuth.jsx
@@ -45,7 +45,7 @@ export default (allowedRoles = ['authenticated']) => (WrappedComponent) => {
           // console.log('pass validation');
         }, () => {
           if (process.browser) {
-            document.cookie = 'authToken=;';
+            document.cookie = 'authToken=; path=/';
           }
           api.setToken('');
           redirectTo('/login', { res: ctx.res, status: 301 });
@@ -63,7 +63,7 @@ export default (allowedRoles = ['authenticated']) => (WrappedComponent) => {
           // ignore this error
         }
         if (process.browser) {
-          document.cookie = 'authToken=;';
+          document.cookie = 'authToken=; path=/';
         }
         redirectTo('/login', { res: ctx.res, status: 301 });
         return { ...pageProps };


### PR DESCRIPTION
After Mitchell added ag-grid to the homepage we have had major issues with redirection after login. This PR fixes that by applying a hacky fix for next-css css imports by adding a blank css file to the _app.jsx page. This apparently does something to fix the css import resolver and fixes Router.push not being able to redirect correctly...

I've also added a notification on the login page that listens to Router and will output an error if the .push event for redirecting to / on login fails. It tells them to close and re-open their browser. This may or may not work. But will give Kelly a good idea what might be going on.
![image](https://user-images.githubusercontent.com/27971797/56102459-d929c280-5ef2-11e9-9b6f-2993326d979d.png)
