### PR TITLE
Feature/schema 4 15

### DIFF
--- a/zoo_api/common/models/DIET_CHANGES.json
+++ b/zoo_api/common/models/DIET_CHANGES.json
@@ -7,7 +7,12 @@
       "table": "DIET_CHANGES"
     },
     "relations": {
-      "dietChangesDiets": {
+      "dietChangeAccount": {
+        "model": "Account",
+        "type": "belongsTo",
+        "foreignKey": "userId"
+      },
+      "dietChangeDiet": {
         "model": "Diets",
         "type": "belongsTo",
         "foreignKey": "dietId"
@@ -103,6 +108,21 @@
         "dataLength": 255,
         "dataPrecision": null,
         "dataScale": null,
+        "nullable": "Y"
+      }
+    },
+    "userId": {
+      "type": "Number",
+      "required": false,
+      "length": null,
+      "precision": 10,
+      "scale": 0,
+      "mysql": {
+        "columnName": "user_id",
+        "dataType": "int",
+        "dataLength": null,
+        "dataPrecision": 10,
+        "dataScale": 0,
         "nullable": "Y"
       }
     }

--- a/zoo_api/common/models/DIET_HISTORY.json
+++ b/zoo_api/common/models/DIET_HISTORY.json
@@ -12,7 +12,12 @@
         "type": "belongsTo",
         "foreignKey": "dietId"
       },
-      "dietHistoryEmployees": {
+      "dietHistoryDietChange": {
+        "model": "DietChanges",
+        "type": "belongsTo",
+        "foreignKey": "dietChangeId"
+      },
+      "dietHistoryEmployee": {
         "model": "Employees",
         "type": "belongsTo",
         "foreignKey": "bgtUserId"
@@ -360,6 +365,32 @@
         "dataScale": 0,
         "nullable": "Y"
       }
+    },
+    "dietChangeId": {
+      "type": "Number",
+      "required": false,
+      "length": null,
+      "precision": 10,
+      "scale": 0,
+      "mysql": {
+        "columnName": "diet_change_id",
+        "dataType": "int",
+        "dataLength": null,
+        "dataPrecision": 10,
+        "dataScale": 0,
+        "nullable": "Y"
+      }
     }
+  },
+  "validations": [],
+  "relations": {},
+  "acls": [
+    {
+      "accessType": "*",
+      "principalType": "ROLE",
+      "principalId": "$unauthenticated",
+      "permission": "DENY"
     }
+  ],
+  "methods": {}
 }

--- a/zoo_api/discover-models.js
+++ b/zoo_api/discover-models.js
@@ -21,7 +21,7 @@ const mkdirp = promisify(require('mkdirp'));
 const DATASOURCE_NAME = 'zoo_mysql';
 const dataSourceConfig = require('./server/datasources.production');
 
-const MODELNAME = 'DIETS'; // CHANGE ME WHEN UPDATING MODEL SCHEMA
+const MODELNAME = 'DIET_HISTORY'; // CHANGE ME WHEN UPDATING MODEL SCHEMA
 
 const db = new loopback.DataSource(dataSourceConfig[DATASOURCE_NAME]);
 async function discover() {


### PR DESCRIPTION
🚨🚨SCHEMA UPDATE🚨🚨

Tables updated
- DIET_CHANGES
    - added user_id int(11)
    - added FK to account that maps user_id to id of account so we can assign current user to diet change when it is created
- DIET_HISTORY
    - added diet_change_id int(10)
    - added FK to DIET_CHANGES that maps diet_change_id to diet_change_id of DIET_CHANGES so that we can have the option to assign a diet change to a diet history and display the details of a diet change directly under the table if desired.

All Loopback relationships and models have been updated accordingly using the discover-models.js script